### PR TITLE
Add self-sizing feature with utilizing intrinsic content size

### DIFF
--- a/Example/Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0zV-ZM-AeL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0zV-ZM-AeL">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +18,7 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -50,11 +51,10 @@
             <objects>
                 <navigationController id="0zV-ZM-AeL" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="YIJ-65-bX7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="ZuY-QC-Xpc">
-                        <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </toolbar>
                     <connections>
@@ -120,7 +120,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" id="JQv-Ma-12I"/>
+                                                    <constraint firstAttribute="height" placeholder="YES" id="JQv-Ma-12I"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -152,7 +152,6 @@
                     </view>
                     <connections>
                         <outlet property="mdView" destination="7IU-tq-2e9" id="ppI-98-j5H"/>
-                        <outlet property="mdViewHeight" destination="JQv-Ma-12I" id="xAr-B7-CBd"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xrG-jQ-sWD" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -172,7 +171,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="izT-Tv-hzD">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="76" width="375" height="591"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DNa-7Z-b9M">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
@@ -181,7 +180,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" id="Gig-Pn-LYq"/>
+                                                    <constraint firstAttribute="height" placeholder="YES" id="Gig-Pn-LYq"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -203,7 +202,7 @@
                                 </constraints>
                             </scrollView>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="TAa-ZV-mC7">
-                                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="56"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                         </subviews>
@@ -220,7 +219,6 @@
                     </view>
                     <connections>
                         <outlet property="mdView" destination="dG6-ar-pCb" id="Ecq-Ev-0JV"/>
-                        <outlet property="mdViewHeight" destination="Gig-Pn-LYq" id="VCa-3U-1y9"/>
                         <outlet property="searchBar" destination="TAa-ZV-mC7" id="rIr-Mc-iM0"/>
                     </connections>
                 </viewController>

--- a/Example/Example/Example3ViewController.swift
+++ b/Example/Example/Example3ViewController.swift
@@ -5,16 +5,14 @@ import SafariServices
 class Example3ViewController: UIViewController {
 
   @IBOutlet weak var mdView: MarkdownView!
-  @IBOutlet weak var mdViewHeight: NSLayoutConstraint!
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     mdView.isScrollEnabled = false
 
-    mdView.onRendered = { [weak self] height in
-      self?.mdViewHeight.constant = height
-      self?.view.setNeedsLayout()
+    mdView.onRendered = { height in
+      print(height)
     }
 
     mdView.onTouchLink = { [weak self] request in

--- a/Example/Example/Example4ViewController.swift
+++ b/Example/Example/Example4ViewController.swift
@@ -6,7 +6,6 @@ class Example4ViewController: UIViewController {
 
   @IBOutlet weak var searchBar: UISearchBar!
   @IBOutlet weak var mdView: MarkdownView!
-  @IBOutlet weak var mdViewHeight: NSLayoutConstraint!
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -15,9 +14,8 @@ class Example4ViewController: UIViewController {
 
     mdView.isScrollEnabled = false
 
-    mdView.onRendered = { [weak self] height in
-      self?.mdViewHeight.constant = height
-      self?.view.setNeedsLayout()
+    mdView.onRendered = { height in
+      print(height)
     }
 
     mdView.onTouchLink = { [weak self] request in

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -1,12 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.5)
+    CFPropertyList (3.0.0)
     activesupport (4.2.10)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    atomos (0.1.2)
     claide (1.0.2)
     cocoapods (1.2.1)
       activesupport (>= 4.0.2, < 5)
@@ -31,8 +32,8 @@ GEM
       activesupport (>= 4.0.2, < 5)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.1)
-    cocoapods-downloader (1.1.3)
+    cocoapods-deintegrate (1.0.2)
+    cocoapods-downloader (1.2.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -46,23 +47,24 @@ GEM
     escape (0.0.4)
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
-    gh_inspector (1.0.3)
-    i18n (0.9.0)
+    gh_inspector (1.1.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     molinillo (0.5.7)
-    nanaimo (0.2.3)
+    nanaimo (0.2.5)
     nap (1.1.0)
     netrc (0.11.0)
     ruby-macho (1.1.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.5.2)
-      CFPropertyList (~> 2.3.3)
+    xcodeproj (1.5.7)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.2)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.3)
+      nanaimo (~> 0.2.4)
 
 PLATFORMS
   ruby
@@ -71,4 +73,4 @@ DEPENDENCIES
   cocoapods (= 1.2.1)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MarkdownView (1.1.0)
+  - MarkdownView (1.2.0)
 
 DEPENDENCIES:
   - MarkdownView (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  MarkdownView: 909f1667b27decd6cfc7ef0fddc3cfb59dccb76c
+  MarkdownView: d72e5cca8172402a579d9ba082968af36c2faf56
 
 PODFILE CHECKSUM: 8c5695542d24c72f1a7af0509ff2da8b049ec0bf
 

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "MarkdownView"
-  s.version       = "1.1.0"
+  s.version       = "1.2.0"
   s.summary       = "Markdown View for iOS."
   s.homepage      = "https://github.com/keitaoouchi/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }

--- a/MarkdownView/MarkdownView.swift
+++ b/MarkdownView/MarkdownView.swift
@@ -1,9 +1,20 @@
 import UIKit
 import WebKit
 
+/**
+ Markdown View for iOS.
+ 
+ - Note: [How to get height of entire document with javascript](https://stackoverflow.com/questions/1145850/how-to-get-height-of-entire-document-with-javascript)
+ */
 open class MarkdownView: UIView {
 
   private var webView: WKWebView?
+  
+  private var intrinsicContentHeight: CGFloat? {
+    didSet {
+      self.invalidateIntrinsicContentSize()
+    }
+  }
 
   public var isScrollEnabled: Bool = true {
 
@@ -27,6 +38,14 @@ open class MarkdownView: UIView {
 
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
+  }
+
+  open override var intrinsicContentSize: CGSize {
+    if let height = self.intrinsicContentHeight {
+      return CGSize(width: UIViewNoIntrinsicMetric, height: height)
+    } else {
+      return CGSize.zero
+    }
   }
 
   public func load(markdown: String?, enableImage: Bool = true) {
@@ -86,12 +105,13 @@ open class MarkdownView: UIView {
 extension MarkdownView: WKNavigationDelegate {
 
   public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-    let script = "document.body.offsetHeight;"
+    let script = "document.body.scrollHeight;"
     webView.evaluateJavaScript(script) { [weak self] result, error in
       if let _ = error { return }
 
       if let height = result as? CGFloat {
         self?.onRendered?(height)
+        self?.intrinsicContentHeight = height
       }
     }
   }

--- a/MarkdownView/MarkdownView.swift
+++ b/MarkdownView/MarkdownView.swift
@@ -10,7 +10,7 @@ open class MarkdownView: UIView {
 
   private var webView: WKWebView?
   
-  private var intrinsicContentHeight: CGFloat? {
+  fileprivate var intrinsicContentHeight: CGFloat? {
     didSet {
       self.invalidateIntrinsicContentSize()
     }


### PR DESCRIPTION
This makes it unnecessary for developers to adjust height of markdownView with onRendered callback themselves.