### PR TITLE
Mac catalyst support

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B352A12E40F36FC4F047CAF3 /* Pods_MarkdownView_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */; };
 		DE524D651EC47CB100E8C2F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */; };
 		DE524D671EC47CB100E8C2F9 /* Example1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D661EC47CB100E8C2F9 /* Example1ViewController.swift */; };
 		DE524D6A1EC47CB100E8C2F9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE524D681EC47CB100E8C2F9 /* Main.storyboard */; };
 		DE524D6C1EC47CB100E8C2F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE524D6B1EC47CB100E8C2F9 /* Assets.xcassets */; };
 		DE524D6F1EC47CB100E8C2F9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE524D6D1EC47CB100E8C2F9 /* LaunchScreen.storyboard */; };
-		DF85605DE14EAE2D14E58EB3 /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EAEB7F4358B9EF21E9D96277 /* libPods-Example.a */; };
 		FC2C2EE21ED7B1D70065633B /* Example4ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2C2EE11ED7B1D70065633B /* Example4ViewController.swift */; };
 		FCB2E9471ECA8B7600285B87 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB2E9461ECA8B7600285B87 /* ViewController.swift */; };
 		FCB2E9491ECA929500285B87 /* Example2ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB2E9481ECA929500285B87 /* Example2ViewController.swift */; };
@@ -22,7 +22,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MarkdownView_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		374A40C5244297BE00F839A6 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
+		377721222442AC1900CEFA9D /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Metal.framework; sourceTree = DEVELOPER_DIR; };
+		4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarkdownView Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example.release.xcconfig"; sourceTree = "<group>"; };
 		7DB4CCAB27BE7F6CF35BA1E5 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
+		85492781876DC525E50CBB20 /* Pods-MarkdownView Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarkdownView Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example.debug.xcconfig"; sourceTree = "<group>"; };
 		88E6DEC525FE3CD3BAB79EA8 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		DE524D611EC47CB100E8C2F9 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -31,7 +36,6 @@
 		DE524D6B1EC47CB100E8C2F9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DE524D6E1EC47CB100E8C2F9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DE524D701EC47CB100E8C2F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		EAEB7F4358B9EF21E9D96277 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC2C2EE11ED7B1D70065633B /* Example4ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Example4ViewController.swift; sourceTree = "<group>"; };
 		FCB2E9461ECA8B7600285B87 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		FCB2E9481ECA929500285B87 /* Example2ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Example2ViewController.swift; sourceTree = "<group>"; };
@@ -45,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DF85605DE14EAE2D14E58EB3 /* libPods-Example.a in Frameworks */,
+				B352A12E40F36FC4F047CAF3 /* Pods_MarkdownView_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +59,8 @@
 		5120DE397F30974224FD684A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				EAEB7F4358B9EF21E9D96277 /* libPods-Example.a */,
+				377721222442AC1900CEFA9D /* Metal.framework */,
+				113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -65,6 +70,8 @@
 			children = (
 				88E6DEC525FE3CD3BAB79EA8 /* Pods-Example.debug.xcconfig */,
 				7DB4CCAB27BE7F6CF35BA1E5 /* Pods-Example.release.xcconfig */,
+				85492781876DC525E50CBB20 /* Pods-MarkdownView Example.debug.xcconfig */,
+				4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -90,6 +97,7 @@
 		DE524D631EC47CB100E8C2F9 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				374A40C5244297BE00F839A6 /* Example.entitlements */,
 				FCB2E9501ECAF36500285B87 /* sample.md */,
 				FCB2E94E1ECADF3700285B87 /* README.md */,
 				DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */,
@@ -117,7 +125,7 @@
 				DE524D5D1EC47CB100E8C2F9 /* Sources */,
 				DE524D5E1EC47CB100E8C2F9 /* Frameworks */,
 				DE524D5F1EC47CB100E8C2F9 /* Resources */,
-				A9591DA79983D9E13DB22B4B /* [CP] Copy Pods Resources */,
+				F402596D86B0A34B4D970C9F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -140,7 +148,8 @@
 				TargetAttributes = {
 					DE524D601EC47CB100E8C2F9 = {
 						CreatedOnToolsVersion = 8.3.2;
-						ProvisioningStyle = Manual;
+						DevelopmentTeam = 6F9773F85D;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -178,24 +187,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		A9591DA79983D9E13DB22B4B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/MarkdownView/MarkdownView.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MarkdownView.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		AC7DF812B9F91A932D25CB6D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -207,11 +198,29 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-MarkdownView Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F402596D86B0A34B4D970C9F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/MarkdownView/MarkdownView.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MarkdownView.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -302,10 +311,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
@@ -358,9 +368,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -370,30 +381,46 @@
 		};
 		DE524D741EC47CB100E8C2F9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88E6DEC525FE3CD3BAB79EA8 /* Pods-Example.debug.xcconfig */;
+			baseConfigurationReference = 85492781876DC525E50CBB20 /* Pods-MarkdownView Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6F9773F85D;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.giganom.markdownview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		DE524D751EC47CB100E8C2F9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7DB4CCAB27BE7F6CF35BA1E5 /* Pods-Example.release.xcconfig */;
+			baseConfigurationReference = 4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6F9773F85D;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.giganom.markdownview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3708C8702442C93D0098AD1F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3708C86F2442C93D0098AD1F /* UIKit.framework */; };
 		3B609C9845BD2E3C69B20496 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFBCF05DB1F1317E607E406 /* Pods_Example.framework */; };
 		DE524D651EC47CB100E8C2F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */; };
 		DE524D671EC47CB100E8C2F9 /* Example1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D661EC47CB100E8C2F9 /* Example1ViewController.swift */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3708C86F2442C93D0098AD1F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		374A40C5244297BE00F839A6 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		377721222442AC1900CEFA9D /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Metal.framework; sourceTree = DEVELOPER_DIR; };
 		4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarkdownView Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -49,6 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3708C8702442C93D0098AD1F /* UIKit.framework in Frameworks */,
 				3B609C9845BD2E3C69B20496 /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -59,6 +62,7 @@
 		5120DE397F30974224FD684A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3708C86F2442C93D0098AD1F /* UIKit.framework */,
 				377721222442AC1900CEFA9D /* Metal.framework */,
 				ADFBCF05DB1F1317E607E406 /* Pods_Example.framework */,
 			);

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B352A12E40F36FC4F047CAF3 /* Pods_MarkdownView_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */; };
+		3B609C9845BD2E3C69B20496 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADFBCF05DB1F1317E607E406 /* Pods_Example.framework */; };
 		DE524D651EC47CB100E8C2F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */; };
 		DE524D671EC47CB100E8C2F9 /* Example1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE524D661EC47CB100E8C2F9 /* Example1ViewController.swift */; };
 		DE524D6A1EC47CB100E8C2F9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE524D681EC47CB100E8C2F9 /* Main.storyboard */; };
@@ -22,13 +22,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MarkdownView_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		374A40C5244297BE00F839A6 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		377721222442AC1900CEFA9D /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Metal.framework; sourceTree = DEVELOPER_DIR; };
 		4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarkdownView Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example.release.xcconfig"; sourceTree = "<group>"; };
 		7DB4CCAB27BE7F6CF35BA1E5 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		85492781876DC525E50CBB20 /* Pods-MarkdownView Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarkdownView Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example.debug.xcconfig"; sourceTree = "<group>"; };
 		88E6DEC525FE3CD3BAB79EA8 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		ADFBCF05DB1F1317E607E406 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE524D611EC47CB100E8C2F9 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE524D641EC47CB100E8C2F9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DE524D661EC47CB100E8C2F9 /* Example1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example1ViewController.swift; sourceTree = "<group>"; };
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B352A12E40F36FC4F047CAF3 /* Pods_MarkdownView_Example.framework in Frameworks */,
+				3B609C9845BD2E3C69B20496 /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,7 +60,7 @@
 			isa = PBXGroup;
 			children = (
 				377721222442AC1900CEFA9D /* Metal.framework */,
-				113742E783F806B0A9E56570 /* Pods_MarkdownView_Example.framework */,
+				ADFBCF05DB1F1317E607E406 /* Pods_Example.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -198,7 +198,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-MarkdownView Example-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -211,7 +211,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MarkdownView/MarkdownView.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -220,7 +220,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MarkdownView Example/Pods-MarkdownView Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -381,7 +381,7 @@
 		};
 		DE524D741EC47CB100E8C2F9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 85492781876DC525E50CBB20 /* Pods-MarkdownView Example.debug.xcconfig */;
+			baseConfigurationReference = 88E6DEC525FE3CD3BAB79EA8 /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
@@ -393,7 +393,7 @@
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.giganom.markdownview;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.giganom.markdownview-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -404,7 +404,7 @@
 		};
 		DE524D751EC47CB100E8C2F9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A04D2F8D66FBC3E282BE792 /* Pods-MarkdownView Example.release.xcconfig */;
+			baseConfigurationReference = 7DB4CCAB27BE7F6CF35BA1E5 /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
@@ -416,7 +416,7 @@
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.giganom.markdownview;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.giganom.markdownview-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FCA050141EC41211001DAD5F"
-               BuildableName = "MarkdownView.framework"
-               BlueprintName = "MarkdownView"
-               ReferencedContainer = "container:MarkdownView.xcodeproj">
+               BlueprintIdentifier = "DE524D601EC47CB100E8C2F9"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -40,15 +40,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FCA050141EC41211001DAD5F"
-            BuildableName = "MarkdownView.framework"
-            BlueprintName = "MarkdownView"
-            ReferencedContainer = "container:MarkdownView.xcodeproj">
+            BlueprintIdentifier = "DE524D601EC47CB100E8C2F9"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -56,21 +57,23 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FCA050141EC41211001DAD5F"
-            BuildableName = "MarkdownView.framework"
-            BlueprintName = "MarkdownView"
-            ReferencedContainer = "container:MarkdownView.xcodeproj">
+            BlueprintIdentifier = "DE524D601EC47CB100E8C2F9"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
+      customArchiveName = "MarkdownView Example"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Example/Example.xcworkspace/contents.xcworkspacedata
+++ b/Example/Example.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Example.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Example/Example.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/Example.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,24 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0zV-ZM-AeL">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0zV-ZM-AeL">
+    <device id="mac" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="MarkdownView_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="550"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -31,13 +28,13 @@
         <!--Example1 View Controller-->
         <scene sceneID="bOp-lv-Mj7">
             <objects>
-                <viewController storyboardIdentifier="Example1" id="Q9e-Y0-k5t" customClass="Example1ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Example1" id="Q9e-Y0-k5t" customClass="Example1ViewController" customModule="MarkdownView_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="xPZ-cA-TQj"/>
                         <viewControllerLayoutGuide type="bottom" id="cKH-ns-Z61"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="uai-KV-wIO">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
@@ -51,7 +48,7 @@
             <objects>
                 <navigationController id="0zV-ZM-AeL" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="YIJ-65-bX7">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="ZuY-QC-Xpc">
@@ -68,26 +65,26 @@
         <!--Example2 View Controller-->
         <scene sceneID="kz3-uP-5Qd">
             <objects>
-                <viewController storyboardIdentifier="Example2" id="gJw-yg-Owd" customClass="Example2ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Example2" id="gJw-yg-Owd" customClass="Example2ViewController" customModule="MarkdownView_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="GNh-zc-fCS"/>
                         <viewControllerLayoutGuide type="bottom" id="C1x-to-yGu"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="QmO-2l-Z4V">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Elg-eD-B8F" customClass="MarkdownView" customModule="MarkdownView">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="C1x-to-yGu" firstAttribute="top" secondItem="Elg-eD-B8F" secondAttribute="bottom" id="6Bh-gX-uxc"/>
+                            <constraint firstAttribute="bottom" secondItem="Elg-eD-B8F" secondAttribute="bottom" id="6Bh-gX-uxc"/>
                             <constraint firstItem="Elg-eD-B8F" firstAttribute="leading" secondItem="QmO-2l-Z4V" secondAttribute="leading" id="b0m-Od-Kvi"/>
                             <constraint firstAttribute="trailing" secondItem="Elg-eD-B8F" secondAttribute="trailing" id="iLK-F0-xAo"/>
-                            <constraint firstItem="Elg-eD-B8F" firstAttribute="top" secondItem="GNh-zc-fCS" secondAttribute="bottom" id="uy8-UT-W11"/>
+                            <constraint firstItem="Elg-eD-B8F" firstAttribute="top" secondItem="QmO-2l-Z4V" secondAttribute="top" id="uy8-UT-W11"/>
                         </constraints>
                     </view>
                     <connections>
@@ -101,23 +98,23 @@
         <!--Example3 View Controller-->
         <scene sceneID="n37-1x-Z2p">
             <objects>
-                <viewController storyboardIdentifier="Example3" id="UJp-J8-85f" customClass="Example3ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Example3" id="UJp-J8-85f" customClass="Example3ViewController" customModule="MarkdownView_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bpd-3R-KWH"/>
                         <viewControllerLayoutGuide type="bottom" id="7IQ-R8-o8K"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="uMW-MQ-HcC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QoT-Qh-Bk4">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7TF-Zc-lc6">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="800" height="0.0"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7IU-tq-2e9" customClass="MarkdownView" customModule="MarkdownView">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="800" height="0.0"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" placeholder="YES" id="JQv-Ma-12I"/>
@@ -161,23 +158,23 @@
         <!--Example4 View Controller-->
         <scene sceneID="7bC-E2-cjh">
             <objects>
-                <viewController storyboardIdentifier="Example4" id="dyi-iO-giE" customClass="Example4ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Example4" id="dyi-iO-giE" customClass="Example4ViewController" customModule="MarkdownView_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="fZg-3P-ZYQ"/>
                         <viewControllerLayoutGuide type="bottom" id="NbS-G2-zhP"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="XWG-QA-6Ev">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="izT-Tv-hzD">
-                                <rect key="frame" x="0.0" y="76" width="375" height="591"/>
+                                <rect key="frame" x="0.0" y="50" width="800" height="550"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DNa-7Z-b9M">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="800" height="0.0"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dG6-ar-pCb" customClass="MarkdownView" customModule="MarkdownView">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="800" height="0.0"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" placeholder="YES" id="Gig-Pn-LYq"/>
@@ -202,7 +199,7 @@
                                 </constraints>
                             </scrollView>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="TAa-ZV-mC7">
-                                <rect key="frame" x="0.0" y="20" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="0.0" width="800" height="50"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                         </subviews>

--- a/Example/Example/Example.entitlements
+++ b/Example/Example/Example.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example/Example1ViewController.swift
+++ b/Example/Example/Example1ViewController.swift
@@ -3,23 +3,35 @@ import MarkdownView
 
 class Example1ViewController: UIViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    let mdView = MarkdownView()
-    view.addSubview(mdView)
-    mdView.translatesAutoresizingMaskIntoConstraints = false
-    mdView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor).isActive = true
-    mdView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-    mdView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-    mdView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor).isActive = true
-
-    let path = Bundle.main.path(forResource: "sample", ofType: "md")!
-
-    let url = URL(fileURLWithPath: path)
-    let markdown = try! String(contentsOf: url, encoding: String.Encoding.utf8)
-    mdView.load(markdown: markdown, enableImage: true)
-
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let mdView = MarkdownView()
+        view.addSubview(mdView)
+        mdView.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Apply appropriate constraints
+        if #available(iOS 10.0, *) {
+            mdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+            mdView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        } else if #available(OSX 10.15, *) {
+            print("loading osx constraints")
+            mdView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor).isActive = true
+            mdView.topAnchor.constraint(equalTo: topLayoutGuide.topAnchor).isActive = true
+        } else {
+             // TODO: figure out if other versions have specific reqs
+            #if DEBUG
+            print("unhandled OS / version detected, layout contstraints will not be set")
+            #endif
+         }
+         mdView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+         mdView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        
+        // Load sample
+        let path = Bundle.main.path(forResource: "sample", ofType: "md")!
+        let url = URL(fileURLWithPath: path)
+        let markdown = try! String(contentsOf: url, encoding: String.Encoding.utf8)
+        mdView.load(markdown: markdown, enableImage: true)
   }
-
 }
+

--- a/Example/Example/Example1ViewController.swift
+++ b/Example/Example/Example1ViewController.swift
@@ -11,7 +11,7 @@ class Example1ViewController: UIViewController {
         mdView.translatesAutoresizingMaskIntoConstraints = false
         
         // Apply appropriate constraints
-        if #available(iOS 10.0, *) {
+        if #available(iOS 13.0, *) {
             mdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
             mdView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         } else if #available(OSX 10.15, *) {

--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -18,8 +18,15 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,10 +48,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-  <key>NSAppTransportSecurity</key>
-  <dict>
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-  </dict>
 </dict>
 </plist>

--- a/Example/MarkdownView Example.xcworkspace/contents.xcworkspacedata
+++ b/Example/MarkdownView Example.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/dan/SynologyDrive/SoftwareDevelopment/FrameworkRepositories/Cocoapods/OpenSource/MarkdownView/Example/Example.xcodeproj">
+      location = "group:MarkdownView Example.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,15 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '13.0'
 
-target 'Example' do
-  use_modular_headers!
+# Configured for using separate projects (more performant)
+install! 'cocoapods',
+generate_multiple_pod_projects: true,
+incremental_installation: true
+use_modular_headers!
+
+target 'MarkdownView Example' do
+  use_frameworks!
+  inhibit_all_warnings!
 
   pod 'MarkdownView', path: '../'
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,7 +7,7 @@ generate_multiple_pod_projects: true,
 incremental_installation: true
 use_modular_headers!
 
-target 'MarkdownView Example' do
+target 'Example' do
   use_frameworks!
   inhibit_all_warnings!
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MarkdownView (1.6.1)
+  - MarkdownView (2.0.0)
 
 DEPENDENCIES:
   - MarkdownView (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  MarkdownView: 2754ecdb0ecfee7ea992edf571585c0e91ad53b6
+  MarkdownView: 5e62443913490e680dcea26a71e6316e0a8e2525
 
-PODFILE CHECKSUM: 16046bc05c2c5c7b9701c80dba26f85da748501c
+PODFILE CHECKSUM: 19ba84a4279ca6c41fef2247b7ef3bb8d378ffab
 
 COCOAPODS: 1.8.4

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MarkdownView (1.6.0)
+  - MarkdownView (1.6.1)
 
 DEPENDENCIES:
   - MarkdownView (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  MarkdownView: 25c1c2d7ff9706624a575556296e188be3dd3f6b
+  MarkdownView: 2754ecdb0ecfee7ea992edf571585c0e91ad53b6
 
-PODFILE CHECKSUM: 81524f0576f4f47cc5d483ea9038e72eae263c2e
+PODFILE CHECKSUM: 16046bc05c2c5c7b9701c80dba26f85da748501c
 
-COCOAPODS: 1.7.2
+COCOAPODS: 1.8.4

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
   s.name          = "MarkdownView"
   s.version       = "2.0.0"
   s.summary       = "Markdown View for iOS & macCatalyst applications."
-  s.homepage      = "https://github.com/keitaoouchi/MarkdownView"
+  s.homepage      = "https://github.com/gigabitelabs/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }
   s.author        = { "keitaoouchi" => "keita.oouchi@gmail.com" }
-  s.source        = { :git => "https://github.com/keitaoouchi/MarkdownView.git", :tag => "#{s.version}" }
+  s.source        = { :git => "https://github.com/gigabitelabs/MarkdownView.git", :tag => "#{s.version}" }
   s.source_files  = "MarkdownView/*.swift"
   s.resource_bundles = {
     'MarkdownView' => ['webassets/dist/*']

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name          = "MarkdownView"
-  s.version       = "1.6.0"
-  s.summary       = "Markdown View for iOS."
+  s.version       = "1.6.1"
+  s.summary       = "Markdown View for iOS & macCatalyst applications."
   s.homepage      = "https://github.com/keitaoouchi/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }
   s.author        = { "keitaoouchi" => "keita.oouchi@gmail.com" }
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   }
   s.frameworks    = "Foundation"
   s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.15"
   s.swift_version = '5.0'
 end

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.resource_bundles = {
     'MarkdownView' => ['webassets/dist/*']
   }
-  s.frameworks    = "Foundation"
+  s.ios.frameworks = "Foundation"
+  s.platform = :ios
   s.ios.deployment_target = "13.0"
-  s.osx.deployment_target = "10.15"
   s.swift_version = '5.0'
 end

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "MarkdownView"
-  s.version       = "2.0.0"
+  s.version       = "2.0.1"
   s.summary       = "Markdown View for iOS & macCatalyst applications."
   s.homepage      = "https://github.com/gigabitelabs/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name          = "MarkdownView"
-  s.version       = "2.0.1"
+  s.version       = "2.0.0"
   s.summary       = "Markdown View for iOS & macCatalyst applications."
-  s.homepage      = "https://github.com/gigabitelabs/MarkdownView"
+  s.homepage      = "https://github.com/keitaoouchi/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }
   s.author        = { "keitaoouchi" => "keita.oouchi@gmail.com" }
-  s.source        = { :git => "https://github.com/gigabitelabs/MarkdownView.git", :tag => "#{s.version}" }
+  s.source        = { :git => "https://github.com/keitaoouchi/MarkdownView.git", :tag => "#{s.version}" }
   s.source_files  = "MarkdownView/*.swift"
   s.resource_bundles = {
     'MarkdownView' => ['webassets/dist/*']

--- a/MarkdownView.podspec
+++ b/MarkdownView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "MarkdownView"
-  s.version       = "1.6.1"
+  s.version       = "2.0.0"
   s.summary       = "Markdown View for iOS & macCatalyst applications."
   s.homepage      = "https://github.com/keitaoouchi/MarkdownView"
   s.license       = { :type => "MIT", :file => "LICENSE" }
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     'MarkdownView' => ['webassets/dist/*']
   }
   s.frameworks    = "Foundation"
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "13.0"
   s.osx.deployment_target = "10.15"
   s.swift_version = '5.0'
 end

--- a/MarkdownView.xcodeproj/project.pbxproj
+++ b/MarkdownView.xcodeproj/project.pbxproj
@@ -115,8 +115,9 @@
 				TargetAttributes = {
 					FCA050141EC41211001DAD5F = {
 						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = 6F9773F85D;
 						LastSwiftMigration = 0900;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -125,6 +126,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = FCA0500B1EC41211001DAD5F;
@@ -277,10 +279,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6F9773F85D;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -291,6 +295,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.MarkdownView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
@@ -302,10 +307,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6F9773F85D;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -317,6 +324,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.MarkdownView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.2;

--- a/MarkdownView/MarkdownView.swift
+++ b/MarkdownView/MarkdownView.swift
@@ -1,6 +1,5 @@
 import UIKit
 import WebKit
-import Metal
 
 /**
  Markdown View for iOS.


### PR DESCRIPTION
Commit Msgs:
Enabled markdownview for macCatalyst apps, build settings require iOS 13 + OS X 10.15, symantec version increase for non-backwards compatibility, entitlements modified for RW access to UserDefaults in catalyst, layout contrainsts fixed for running in catalyst env, podspec version increase, summary modified for catalyst compatibility, podfile enables submodules, modular headers, incremental builds, inhibits warnings in podfile. 

Testing:
- both the example and framework updates are fully tested for both iOS and macCatalyst
- Run your own tests by running the example project to iOS sim, and then run it locally to your Mac

Notes :
- Catalyst apps are still early days compared to iOS, but there are a lot of issues with Cocoapods due to lack of cocoa pod support. Therefore, the incrementalized installation settings, and submodule settings in the Podfile are required. 
- If you don't use incremental / submodules, you cannot sign the application, which is an unhandled issue when the .xcworkspace is generated by cocoapods for catalyst apps.
- Also, had to change the bundle / team ID to run and test locally, obv need to change that before update to Cocoapods