### PR TITLE
Fix crash bug in iOS 16 SwiftUI

### DIFF
--- a/Sources/MarkdownView/MarkdownUI.swift
+++ b/Sources/MarkdownView/MarkdownUI.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public final class MarkdownUI: UIViewRepresentable {
+public struct MarkdownUI: UIViewRepresentable {
   private let markdownView: MarkdownView
   
   @Binding public var body: String


### PR DESCRIPTION
Fix 'Fatal error: UIViewRepresentables must be value types: MarkdownUI' in iOS 16 SwiftUI