### PR TITLE
Add ios16 compatibility and improve scrolling handling

### DIFF
--- a/Sources/MarkdownView/MarkdownUI.swift
+++ b/Sources/MarkdownView/MarkdownUI.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public final class MarkdownUI: UIViewRepresentable {
+public struct MarkdownUI: UIViewRepresentable {
   private let markdownView: MarkdownView
   
   @Binding public var body: String
@@ -8,7 +8,7 @@ public final class MarkdownUI: UIViewRepresentable {
   public init(body: String? = nil, css: String? = nil, plugins: [String]? = nil, stylesheets: [URL]? = nil, styled: Bool = true) {
     self._body = .constant(body ?? "")
     self.markdownView = MarkdownView(css: css, plugins: plugins, stylesheets: stylesheets, styled: styled)
-    self.markdownView.isScrollEnabled = false
+    self.markdownView.isScrollEnabled = true
   }
   
   public func onTouchLink(perform action: @escaping ((URLRequest) -> Bool)) -> MarkdownUI {
@@ -29,9 +29,7 @@ extension MarkdownUI {
   }
   
   public func updateUIView(_ uiView: MarkdownView, context: Context) {
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-      self.markdownView.show(markdown: self.body)
-    }
+      self.markdownView.markDown = self.body
   }
   
   public func makeCoordinator() -> () {

--- a/Sources/MarkdownView/MarkdownView.swift
+++ b/Sources/MarkdownView/MarkdownView.swift
@@ -30,6 +30,8 @@ open class MarkdownView: UIView {
   public convenience init() {
     self.init(frame: .zero)
   }
+    
+  public var markDown: String = ""
 
   /// Reserve a web view before displaying markdown.
   /// You can use this for performance optimization.
@@ -117,6 +119,10 @@ extension MarkdownView: WKNavigationDelegate {
       decisionHandler(.allow)
     }
 
+  }
+    
+  public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+      show(markdown: markDown)
   }
 }
 


### PR DESCRIPTION
- change MarkdownUI final class to struct because of swiftUI (iOS 16) add WKNavigationDelegate didFinishNavigation 
- delegate to handle show markdown flow, it is cleaner and more reliable than waiting 0.3 seconds on MarkdownView. there were cases when evaluateJavaScript() threw errors because of a too-early call
-  change isScrollingEnabled to true, now it only starts to scroll horizontally when the content is larger, vertical scrolling not effected by this so its more convenient that way