### PR TITLE
Change "final class" to "struct" for compatibility.

### DIFF
--- a/Sources/MarkdownView/MarkdownUI.swift
+++ b/Sources/MarkdownView/MarkdownUI.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public final class MarkdownUI: UIViewRepresentable {
+public struct MarkdownUI: UIViewRepresentable {
   private let markdownView: MarkdownView
   
   @Binding public var body: String


### PR DESCRIPTION
Because [this](https://blog.eidinger.info/uiviewrepresentables-must-be-value-types).